### PR TITLE
Compatibility with symfony/http-foundation 2.7.2

### DIFF
--- a/src/Stack/Session.php
+++ b/src/Stack/Session.php
@@ -56,6 +56,7 @@ class Session implements HttpKernelInterface, TerminableInterface
                 $session->setId($cookies->get($session->getName()));
             } else {
                 //starts the session if no session exists
+                $session->start();
                 $session->migrate(false);
             }
 


### PR DESCRIPTION
Since symfony/http-foundation 2.7.2, session no longer works.

From our point of view, we call :
 - Session::migrate(false), which calls : 
 - NativeSessionStorage::regenerate(false, null);

The regenerate function, since 2.7.2, calls `loadSession()` which assumes a session has already been started. 

```php
<?php
$session = new Symfony\Component\HttpFoundation\Session\Session();
$session->migrate(false);
$session->start();
// no PHPSESSID in COOKIE
```

whereas

```php
<?php
$session = new Symfony\Component\HttpFoundation\Session\Session();
$session->start();
$session->migrate(false);
// has PHPSESSID in COOKIE
```


See start() and regenerate() method mechanisms in NativeSessionStorage to initialize session.
```php
    public function start()
    {
        if ($this->started) {
            return true;
        }

        if (PHP_VERSION_ID >= 50400 && \PHP_SESSION_ACTIVE === session_status()) {
            throw new \RuntimeException('Failed to start the session: already started by PHP.');
        }

        if (PHP_VERSION_ID < 50400 && !$this->closed && isset($_SESSION) && session_id()) {
            // not 100% fool-proof, but is the most reliable way to determine if a session is active in PHP 5.3
            throw new \RuntimeException('Failed to start the session: already started by PHP ($_SESSION is set).');
        }

        if (ini_get('session.use_cookies') && headers_sent($file, $line)) {
            throw new \RuntimeException(sprintf('Failed to start the session because headers have already been sent by "%s" at line %d.', $file, $line));
        }

        // ok to try and start the session
        if (!session_start()) {
            throw new \RuntimeException('Failed to start the session');
        }

        $this->loadSession();
        if (!$this->saveHandler->isWrapper() && !$this->saveHandler->isSessionHandlerInterface()) {
            // This condition matches only PHP 5.3 with internal save handlers
            $this->saveHandler->setActive(true);
        }

        return true;
    }
```
Notice here the call to session_start() before the call to loadSession()

```php
    public function regenerate($destroy = false, $lifetime = null)
    {
        if (null !== $lifetime) {
            ini_set('session.cookie_lifetime', $lifetime);
        }

        if ($destroy) {
            $this->metadataBag->stampNew();
        }

        $isRegenerated = session_regenerate_id($destroy);

        // The reference to $_SESSION in session bags is lost in PHP7 and we need to re-create it.
        // @see https://bugs.php.net/bug.php?id=70013
        $this->loadSession();

        return $isRegenerated;
    }
```
Notice that session_regenerate_id() is called before any call to session_start()



And for the little story, the patch done by Symfony for PHP7 is weird (fix for an alpha ?), here the timeline :
 - PHP7 alpha2 released June 23rd
 - Bug report on July 8th.
 - Fix on Symfony repo on July 8th.
 - PHP7 beta1 released on July 10th
 - Bug report changed to "revert session to PHP5 behaviour to avoid any issue"

-_-