### PR TITLE
Introduce request ID middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
         "twig/twig": "~1.0",
         "symfony/event-dispatcher": "~2.7"
     },
+    "suggest": {
+        "ramsey/uuid": "Request ID middleware"
+    },
     "require-dev": {
         "symfony/debug": "~2.7"
     },

--- a/src/KernelStack/RequestIdMiddleware.php
+++ b/src/KernelStack/RequestIdMiddleware.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Pyrite\KernelStack;
+
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class RequestIdMiddleware implements HttpKernelInterface
+{
+    /** @var HttpKernelInterface  */
+    private $app;
+
+    /** @var string  */
+    private $header;
+
+    /** @var string|null  */
+    private $responseHeader;
+
+    /** @var string */
+    private $uuid;
+
+    /**
+     * RequestIdMiddleware constructor.
+     *
+     * @param HttpKernelInterface $app
+     * @param string              $header
+     * @param string|null                $responseHeader
+     * @param string|null  $uuid
+     */
+    public function __construct(
+        HttpKernelInterface $app,
+        $header = 'X-Request-Id',
+        $responseHeader = null,
+        $uuid = null
+    ) {
+        $this->app            = $app;
+        $this->header         = $header;
+        $this->responseHeader = $responseHeader;
+        $this->uuid = $this->uuid = (string) (null === $uuid ? Uuid::uuid4() : $uuid);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    {
+        if ( ! $request->headers->has($this->header)) {
+            $request->headers->set($this->header, $this->uuid);
+        }
+
+        $response = $this->app->handle($request, $type, $catch);
+
+        if (null !== $this->responseHeader) {
+            $response->headers->set($this->responseHeader, $request->headers->get($this->header));
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param string $header
+     */
+    public function enableResponseHeader($header = 'X-Request-Id')
+    {
+        $this->responseHeader = $header;
+    }
+}


### PR DESCRIPTION
Quandidate Request ID middleware is not maintenaned and UUID lib has a new major release wich make it incompatible with some application using uuid ^3

More over, all applications while rely on the same middleware instead of have they own impl 