### PR TITLE
feat: make exception great again

### DIFF
--- a/src/Kernel/PyriteKernel.php
+++ b/src/Kernel/PyriteKernel.php
@@ -194,12 +194,7 @@ class PyriteKernel implements HttpKernelInterface, TerminableInterface
                 $routeName = $subscription->getRouteName();
 
                 if($code >= 500){
-                    $this->loggerFactory->getLogger('app')->critical('Error raised', array(
-                        'message' => $e->getMessage(),
-                        'trace' => $e->getTraceAsString(),
-                        'line' => $e->getLine(),
-                        'file' => $e->getFile(),
-                    ));
+                    $this->loggerFactory->getLogger('app')->emergency($e);
                 }
 
                 $request->attributes->set('_route', $routeName);

--- a/src/KernelStack/LoggerMiddleware.php
+++ b/src/KernelStack/LoggerMiddleware.php
@@ -52,21 +52,6 @@ class LoggerMiddleware implements HttpKernelInterface, TerminableInterface
             $this->loggerFactory->addTag('request_id', $request->headers->get('X-Request-Id'));
         }
 
-        if(class_exists('Trolamine\Core\Authentication\AnonymousAuthenticationToken')){
-            $username = 'anonymous';
-
-            if(null !== $session = $request->getSession()){
-                /** @var BaseAuthentication $auth */
-                $auth = $session->getBag('attributes')->get('authentication');
-
-                if($auth instanceof BaseAuthentication){
-                    $username = $auth->getAuthenticatedUser()->getUsername();
-                }
-            }
-
-            $this->loggerFactory->addTag('user', $username);
-        }
-
         return $this->app->handle($request, $type, $catch);
     }
 

--- a/src/Logger/ExceptionLoggerDecorator.php
+++ b/src/Logger/ExceptionLoggerDecorator.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Pyrite\Logger;
+
+use Psr\Log\LoggerInterface;
+
+class ExceptionLoggerDecorator implements LoggerInterface
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * ExceptionLoggerDecorator constructor.
+     *
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    private function normalizeData(\Exception $error)
+    {
+        $data[] = [
+            'message'        => $error->getMessage(),
+            'line'           => $error->getLine(),
+            'file'           => $error->getFile(),
+            'trace_as_array' => $error->getTrace(),
+            'type'           => get_class($error),
+        ];
+
+        if (null !== $error->getPrevious()) {
+            $data = array_merge($data, $this->normalizeData($error->getPrevious()));
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param \Exception $e
+     *
+     * @return array
+     */
+    private function renderException(\Exception $e)
+    {
+        // Push the first exception raised from the tail to the head (more relevant exception)
+        $exceptions = array_reverse($this->normalizeData($e));
+        $exceptionId = uniqid('exception-', true);
+
+        $exceptionNumber = count($exceptions);
+
+        foreach($exceptions as $index => $exception){
+            $currentPosition = $exceptionNumber - $index;
+            $exception['id'] = $exceptionId;
+
+            $exceptions[$index]['message'] = sprintf('%d/%d %s (%s)', $currentPosition, $exceptionNumber, $exception['message'], $exception['type']);
+
+            foreach($exception['trace_as_array'] as $position => $trace){
+                if (!isset($trace['file']) && !isset($trace['line'])) {
+                    $betterTrace = sprintf(
+                        '#%d %s::%s() ',
+                        $position,
+                        isset($trace['class']) ? $trace['class'] : '',
+                        $trace['function']
+                    );
+                } else {
+                    $betterTrace = sprintf(
+                        '#%d %s[:%d] - %s::%s() ',
+                        $position,
+                        isset($trace['file']) ? $trace['file'] : '',
+                        isset($trace['line']) ? $trace['line'] : 'N/A',
+                        isset($trace['class']) ? $trace['class'] : '',
+                        $trace['function']
+                    );
+                }
+
+                $exceptions[$index]['trace_as_array'][$position] = $betterTrace;
+            }
+        }
+
+        return $exceptions;
+    }
+
+    public function emergency($message, array $context = [])
+    {
+        if($message instanceof \Exception){
+            $exceptions = $this->renderException($message);
+
+            foreach($exceptions as $exception){
+                $errorContext = ['exception' => $exception];
+                $this->logger->emergency($exception['message'], array_merge($context, $errorContext));
+            }
+        }else{
+            $this->logger->emergency($message, $context);
+        }
+    }
+
+    public function alert($message, array $context = [])
+    {
+        if($message instanceof \Exception){
+            $exceptions = $this->renderException($message);
+
+            foreach($exceptions as $exception){
+                $errorContext = ['exception' => $exception];
+                $this->logger->alert($exception['message'], array_merge($context, $errorContext));
+            }
+        }else{
+            $this->logger->alert($message, $context);
+        }
+    }
+
+    public function critical($message, array $context = [])
+    {
+        if($message instanceof \Exception){
+            $exceptions = $this->renderException($message);
+
+            foreach($exceptions as $exception){
+                $errorContext = ['exception' => $exception];
+                $this->logger->critical($exception['message'], array_merge($context, $errorContext));
+            }
+        }else{
+            $this->logger->critical($message, $context);
+        }
+    }
+
+    /**
+     * @param string $message
+     * @param array  $context
+     */
+    public function error($message, array $context = [])
+    {
+        if($message instanceof \Exception){
+            $exceptions = $this->renderException($message);
+
+            foreach($exceptions as $exception){
+                $errorContext = ['exception' => $exception];
+                $this->logger->error($exception['message'], array_merge($context, $errorContext));
+            }
+        }else{
+            $this->logger->error($message, $context);
+        }
+    }
+
+    public function warning($message, array $context = [])
+    {
+        if($message instanceof \Exception){
+            $exceptions = $this->renderException($message);
+
+            foreach($exceptions as $exception){
+                $errorContext = ['exception' => $exception];
+                $this->logger->warning($exception['message'], array_merge($context, $errorContext));
+            }
+        }else{
+            $this->logger->warning($message, $context);
+        }
+    }
+
+    /**
+     * @param string $message
+     * @param array  $context
+     */
+    public function notice($message, array $context = [])
+    {
+        $this->logger->notice($message, $context);
+    }
+
+    /**
+     * @param string $message
+     * @param array  $context
+     */
+    public function info($message, array $context = [])
+    {
+        $this->logger->info($message, $context);
+    }
+
+    /**
+     * @param string $message
+     * @param array  $context
+     */
+    public function debug($message, array $context = [])
+    {
+        $this->logger->debug($message, $context);
+    }
+
+    /**
+     * @param mixed  $level
+     * @param string $message
+     * @param array  $context
+     */
+    public function log($level, $message, array $context = [])
+    {
+        $this->logger->log($level, $message, $context);
+    }
+
+}

--- a/src/Logger/LoggerFactory.php
+++ b/src/Logger/LoggerFactory.php
@@ -133,7 +133,9 @@ final class LoggerFactory
     public function create($channelName)
     {
         if(!isset($this->loggers[$channelName])){
-            $this->loggers[$channelName] = new Logger($channelName, $this->handlers, $this->processors);
+            $this->loggers[$channelName] = new ExceptionLoggerDecorator(
+                new Logger($channelName, $this->handlers, $this->processors)
+            );
         }
 
         return $this->loggers[$channelName];


### PR DESCRIPTION
Problem : 

1. Exception are not readable in log saas platform because json is fucked by stack trace,so unreadable  
2. Only the first exception of the chain is raised in our monitoring tool
3. Each time we need to log an error we have to write a dedicated logic in order to properly log it, make inconsistent index on our log platform. 

Following psr method have been overloaded : 

- warning
- emergency
- alert
- critical
- error

Those problems are fixed with this PR : 

```php
        $e = new \Exception('Master big error muhahahaha', 0, new \Exception('Something went wrong', 0, new \Exception('Unable to display page')));

        $this->logger->error($e);
```

Now this will trigger 3 errors logs (One by exceptions) See it on slack in our php chan 
All errors raised are linked with an id 

