### PR TITLE
Correctly decode attributes in URL

### DIFF
--- a/src/KernelStack/HttpMiddleware.php
+++ b/src/KernelStack/HttpMiddleware.php
@@ -79,7 +79,7 @@ class HttpMiddleware implements HttpKernelInterface, TerminableInterface
         $this->router->setUrlGenerator($configuration->getUrlGenerator());
         $this->router->setUrlMatcher(new UrlMatcher($routeCollection, $context));
 
-        $request->attributes->add($this->router->match($request->getPathInfo()));
+        $request->attributes->add($this->router->match(rawurldecode($request->getPathInfo())));
         $route = $routeCollection->get($request->attributes->get('_route'));
 
         if(null === $route->getOption('dispatch')){


### PR DESCRIPTION
With this kind of path:`/hello/{name}`, when the URL `/hello/%5Bsquare%20bracket%5D` is hitted, the `Request` object will receive `%5Bsquare%20bracket%5D` while we expected the decoded form: `[square bracket]`. This PR fix this.

The Symfony Routing component handles it [in the generated `Matcher`](https://github.com/symfony/routing/blob/master/Matcher/Dumper/PhpMatcherDumper.php#L107).