### PR TITLE
Remove useless code

### DIFF
--- a/src/Kernel/PyriteKernel.php
+++ b/src/Kernel/PyriteKernel.php
@@ -244,8 +244,6 @@ class PyriteKernel implements HttpKernelInterface, TerminableInterface
             $this->isResolved = true;
         }
 
-        $request = $request ?: Request::createFromGlobals();
-
         $response = $this->resolvedApp->handle($request, $type);
         $response->send();
 


### PR DESCRIPTION
I don't see case where this code portion can be useful, the type hinting on `Request` enforcing a truthy `$request`.