### PR TITLE
fix: Let OutputBuilders do their stuff with the ResponseBag and not write messy headers

### DIFF
--- a/src/Layer/OutputLayer.php
+++ b/src/Layer/OutputLayer.php
@@ -22,13 +22,7 @@ class OutputLayer extends AbstractLayer
 
         $builder = isset($this->outputBuilders[$format]) ? $this->outputBuilders[$format] : $this->defaultOutputBuilder;
 
-        $data = $builder->buildOutput($bag);
-        $headers = $builder->getHeaders($bag);
-        foreach ($headers as $header) {
-            header($header);
-        }
-
-        $bag->setResult($data);
+        $builder->buildOutput($bag);
     }
 
     public function addOutputBuilder($format, OutputBuilder $builder)

--- a/src/OutputBuilder/BinaryOutputBuilder.php
+++ b/src/OutputBuilder/BinaryOutputBuilder.php
@@ -12,13 +12,7 @@ class BinaryOutputBuilder implements OutputBuilder
     const AUTO_ETAG = 'output.binary.auto_etag';
     const AUTO_LAST_MODIFIED = 'output.binary.auto_last_modified';
 
-    public function getHeaders(ResponseBag $bag)
-    {
-        return $bag->getHeaders();
-    }
-
     public function buildOutput(ResponseBag $bag)
     {
-        //nothing
     }
 }

--- a/src/OutputBuilder/HtmlOutputBuilder.php
+++ b/src/OutputBuilder/HtmlOutputBuilder.php
@@ -6,14 +6,10 @@ use Pyrite\Response\ResponseBag;
 
 class HtmlOutputBuilder implements OutputBuilder
 {
-
-    public function getHeaders(ResponseBag $bag)
-    {
-        return array('Content-type: text/html; charset=UTF-8');
-    }
-
     public function buildOutput(ResponseBag $bag)
     {
-        return '<pre>'.print_r($bag->get('data'), true).'</pre>';
+        $bag->addHeader('Content-type', 'text/html; charset=UTF-8');
+
+        $bag->setResult('<pre>'.print_r($bag->get('data'), true).'</pre>');
     }
 }

--- a/src/OutputBuilder/JsonOutputBuilder.php
+++ b/src/OutputBuilder/JsonOutputBuilder.php
@@ -6,13 +6,10 @@ use Pyrite\Response\ResponseBag;
 
 class JsonOutputBuilder implements OutputBuilder
 {
-    public function getHeaders(ResponseBag $bag)
-    {
-        return array('Content-type: application/json; charset=UTF-8');
-    }
-
     public function buildOutput(ResponseBag $bag)
     {
-        return json_encode($bag->get('data'), JSON_NUMERIC_CHECK);
+        $bag->addHeader('Content-type', 'application/json; charset=UTF-8');
+
+        $bag->setResult(json_encode($bag->get('data'), JSON_NUMERIC_CHECK));
     }
 }

--- a/src/OutputBuilder/OutputBuilder.php
+++ b/src/OutputBuilder/OutputBuilder.php
@@ -7,6 +7,4 @@ use Pyrite\Response\ResponseBag;
 interface OutputBuilder
 {
     public function buildOutput(ResponseBag $bag);
-
-    public function getHeaders(ResponseBag $bag);
 }

--- a/src/OutputBuilder/StreamedOutputBuilder.php
+++ b/src/OutputBuilder/StreamedOutputBuilder.php
@@ -11,7 +11,12 @@ class StreamedOutputBuilder implements OutputBuilder
     /** @see RFC6266 */
     const ATTACHMENT_DISPOSITION = 'output.streamed.attachment_disposition';
 
-    public function getHeaders(ResponseBag $bag)
+    /**
+     * @param ResponseBag $bag
+     *
+     * @throws \Exception
+     */
+    public function buildOutput(ResponseBag $bag)
     {
         if (!$bag->has(self::FILENAME)) {
             throw new \Exception('Missing filename for streamed response');
@@ -22,11 +27,5 @@ class StreamedOutputBuilder implements OutputBuilder
         $bag->addHeader('Transfer-Encoding', 'chunked');
         $bag->addHeader('Content-Type', 'application/force-download');
         $bag->addHeader('Content-Disposition', sprintf('%s; filename="%s"', $bag->get(self::ATTACHMENT_DISPOSITION, 'attachment'), $bag->get(self::FILENAME)));
-
-        return $bag->getHeaders();
-    }
-
-    public function buildOutput(ResponseBag $bag)
-    {
     }
 }

--- a/src/OutputBuilder/XmlOutputBuilder.php
+++ b/src/OutputBuilder/XmlOutputBuilder.php
@@ -6,14 +6,10 @@ use Pyrite\Response\ResponseBag;
 
 class XmlOutputBuilder implements OutputBuilder
 {
-
-    public function getHeaders(ResponseBag $bag)
-    {
-        return array('Content-type: application/xml; charset=UTF-8');
-    }
-
     public function buildOutput(ResponseBag $bag)
     {
-        return xmlrpc_encode($bag->get('data'));
+        $bag->addHeader('Content-type', 'application/xml; charset=UTF-8');
+
+        $bag->setResult(xmlrpc_encode($bag->get('data')));
     }
 }


### PR DESCRIPTION
The method `getHeaders` of output builders return either the array of headers of the ResponseBbag or an array of string with
headers, the response headers was messy:
```
export.csv:
no:
chunked:
application/octet-stream:
X-Sendfile: export.csv
```

It's okay with HTTP/1.1 but not HTTP/2.

Headers are already written (and well) by `\Pyrite\Stack\Application::buildResponseFromResponseBag` using the ResponesBag headers.

Breaking change: OutputBuilder interface changed.